### PR TITLE
fix: Measures against division by zero

### DIFF
--- a/frontend/src/store/dataOperations.ts
+++ b/frontend/src/store/dataOperations.ts
@@ -138,7 +138,7 @@ const calculateStats = (validators: any[], uniqueDomains: any[]) => {
     dominance: undefined
   };
 
-  stats.dominance = stats.runByRipple / stats.total;
+  stats.dominance = stats.total !== 0 ? stats.runByRipple / stats.total : 0;
   return stats;
 };
 


### PR DESCRIPTION
When filtering the domain, division by zero occurs when the Total Validator becomes zero.
As a result, coping with the problem that the calculation result becomes NaN.